### PR TITLE
Improve load GUI and simulation

### DIFF
--- a/Ahorros.py
+++ b/Ahorros.py
@@ -124,6 +124,8 @@ def graficar_ahorro_largo_plazo(costo_sistema: float, daily_kwh: float, nombre: 
     plt.close()
     
 def main() -> None:
+    """Abre una interfaz grafica para la simulacion."""
+
     if not os.path.exists(FILE):
         crear_excel_de_ejemplo(FILE)
         print(f"Se creó el archivo '{FILE}' con datos de ejemplo.")
@@ -133,38 +135,137 @@ def main() -> None:
         print(f"Se creó el archivo '{LOADS_FILE}' con datos de ejemplo.")
 
     datos = leer_datos(FILE)
-    cargas = leer_cargas(LOADS_FILE)
-    cargas = seleccionar_cargas_gui(cargas)
-    curva = curva_irradiacion_cusco()
-    potencia_panel, capacidad_bateria = calcular_necesidades(cargas, curva)
-    demanda_maxima = potencia_maxima_demanda(cargas)
-    presupuestos = calcular_kit(datos, potencia_panel, capacidad_bateria, demanda_maxima)
+    cargas_base = leer_cargas(LOADS_FILE)
 
-    daily_kwh = energia_diaria_kwh(cargas, curva)
+    try:
+        from PyQt5 import QtCore, QtGui, QtWidgets
+    except Exception as exc:  # pragma: no cover - dependencias ausentes
+        print(f"No se pudo abrir la interfaz grafica: {exc}")
+        return
 
-    print(f"Consumo diario: {daily_kwh:.2f} kWh")
-    print(f"Potencia de panel requerida: {potencia_panel:.2f} W")
-    print(f"Capacidad de batería requerida: {capacidad_bateria:.2f} Ah")
+    app = QtWidgets.QApplication([])
+    ventana = QtWidgets.QWidget()
+    ventana.setWindowTitle("Simulador Solar")
+    layout = QtWidgets.QVBoxLayout(ventana)
 
-    for categoria in CATEGORIES:
-        pres = presupuestos[categoria]
-        costo, costo_kwh, payback, ahorro = calcular_amortizacion(pres, daily_kwh)
-        print(f"\n{categoria}:")
-        print(f"  Costo sistema: {costo:.2f} PEN")
-        print(f"  Costo amortizado por kWh: {costo_kwh:.2f} PEN")
-        print(f"  Tiempo de amortización: {payback:.2f} años")
-        print(f"  Ahorro estimado a {VIDA_UTIL_ANIOS} años: {ahorro:.2f} PEN")
-        try:
-            graficar_costo_acumulado(costo, daily_kwh, categoria)
+    headers = ["Usar", "Aparato", "Cantidad", "Carga(W)", "HorasDia", "HorasNoche"]
+    tabla = QtWidgets.QTableWidget(len(cargas_base), len(headers))
+    tabla.setHorizontalHeaderLabels(headers)
+    ventana.resize(800, 600)
 
-            graficar_costo_anual(costo, daily_kwh, categoria)
-            graficar_ahorro_largo_plazo(costo, daily_kwh, categoria)
-            print(
-                f"  Graficos guardados: costo_{categoria}.png, costo_anual_{categoria}.png, ahorro_{categoria}.png"
+    for fila, carga in enumerate(cargas_base):
+        chk = QtWidgets.QTableWidgetItem()
+        chk.setCheckState(QtCore.Qt.Checked)
+        tabla.setItem(fila, 0, chk)
+        tabla.setItem(fila, 1, QtWidgets.QTableWidgetItem(carga["aparato"]))
+        tabla.setItem(fila, 2, QtWidgets.QTableWidgetItem(str(carga["cantidad"])))
+        tabla.setItem(fila, 3, QtWidgets.QTableWidgetItem(str(carga["carga"])))
+        tabla.setItem(fila, 4, QtWidgets.QTableWidgetItem(str(carga["horas_dia"])))
+        tabla.setItem(fila, 5, QtWidgets.QTableWidgetItem(str(carga["horas_noche"])))
+
+    layout.addWidget(tabla)
+
+    btn_ejecutar = QtWidgets.QPushButton("Ejecutar simulacion")
+    layout.addWidget(btn_ejecutar)
+
+    cont_botones = QtWidgets.QHBoxLayout()
+    btn_costo = QtWidgets.QPushButton("Costo acumulado")
+    btn_anual = QtWidgets.QPushButton("Costo anual")
+    btn_ahorro = QtWidgets.QPushButton("Ahorro")
+    btn_sistemas = QtWidgets.QPushButton("Sistemas")
+    for b in (btn_costo, btn_anual, btn_ahorro, btn_sistemas):
+        b.setEnabled(False)
+        cont_botones.addWidget(b)
+    layout.addLayout(cont_botones)
+
+    salida = QtWidgets.QTextEdit()
+    salida.setReadOnly(True)
+    layout.addWidget(salida)
+
+    resultados: Dict[str, Dict[str, Tuple[str, float]]] = {}
+    daily_kwh: float = 0.0
+
+    def ejecutar() -> None:
+        nonlocal resultados, daily_kwh
+        cargas: list[dict[str, float]] = []
+        for row in range(tabla.rowCount()):
+            if tabla.item(row, 0).checkState() != QtCore.Qt.Checked:
+                continue
+            aparato = tabla.item(row, 1).text()
+            cantidad = float(tabla.item(row, 2).text() or 0)
+            carga_w = float(tabla.item(row, 3).text() or 0)
+            horas_dia = float(tabla.item(row, 4).text() or 0)
+            horas_noche = float(tabla.item(row, 5).text() or 0)
+            cargas.append(
+                {
+                    "aparato": aparato,
+                    "cantidad": cantidad,
+                    "carga": carga_w,
+                    "horas_dia": horas_dia,
+                    "horas_noche": horas_noche,
+                }
             )
 
-        except ImportError as exc:
-            print(f"  No se pudo generar grafico: {exc}")
+        curva = curva_irradiacion_cusco()
+        pot_panel, cap_bat = calcular_necesidades(cargas, curva)
+        demanda_max = potencia_maxima_demanda(cargas)
+        resultados = calcular_kit(datos, pot_panel, cap_bat, demanda_max)
+        daily_kwh = energia_diaria_kwh(cargas, curva)
+
+        texto = (
+            f"Consumo diario: {daily_kwh:.2f} kWh\n"
+            f"Potencia de panel requerida: {pot_panel:.2f} W\n"
+            f"Capacidad de bateria requerida: {cap_bat:.2f} Ah"
+        )
+        salida.setPlainText(texto)
+
+        # Graficos para la categoria Barato por defecto
+        pres = resultados[CATEGORIES[0]]
+        costo, _, _, _ = calcular_amortizacion(pres, daily_kwh)
+        graficar_costo_acumulado(costo, daily_kwh, "resultado")
+        graficar_costo_anual(costo, daily_kwh, "resultado")
+        graficar_ahorro_largo_plazo(costo, daily_kwh, "resultado")
+
+        for b in (btn_costo, btn_anual, btn_ahorro, btn_sistemas):
+            b.setEnabled(True)
+
+    def mostrar_imagen(ruta: str) -> None:
+        dlg = QtWidgets.QDialog(ventana)
+        lbl = QtWidgets.QLabel()
+        pix = QtGui.QPixmap(ruta)
+        lbl.setPixmap(pix)
+        lay = QtWidgets.QVBoxLayout(dlg)
+        lay.addWidget(lbl)
+        dlg.exec_()
+
+    def mostrar_sistemas() -> None:
+        texto = ""
+        for cat in CATEGORIES:
+            pres = resultados.get(cat, {})
+            if not pres:
+                continue
+            costo, costo_kwh, payback, ahorro = calcular_amortizacion(pres, daily_kwh)
+            texto += f"{cat}: {costo:.2f} PEN\n"
+            for comp, (desc, precio) in pres.items():
+                texto += f"  {comp}: {desc} - {precio:.2f} PEN\n"
+            texto += (
+                f"  Costo kWh: {costo_kwh:.2f} PEN\n"
+                f"  Payback: {payback:.2f} años\n"
+                f"  Ahorro {VIDA_UTIL_ANIOS} años: {ahorro:.2f} PEN\n\n"
+            )
+        dlg = QtWidgets.QMessageBox(ventana)
+        dlg.setWindowTitle("Sistemas recomendados")
+        dlg.setText(texto)
+        dlg.exec_()
+
+    btn_ejecutar.clicked.connect(ejecutar)
+    btn_costo.clicked.connect(lambda: mostrar_imagen("costo_resultado.png"))
+    btn_anual.clicked.connect(lambda: mostrar_imagen("costo_anual_resultado.png"))
+    btn_ahorro.clicked.connect(lambda: mostrar_imagen("ahorro_resultado.png"))
+    btn_sistemas.clicked.connect(mostrar_sistemas)
+
+    ventana.show()
+    app.exec_()
 
 
 if __name__ == "__main__":

--- a/Precios.py
+++ b/Precios.py
@@ -104,15 +104,13 @@ def crear_excel_cargas_de_ejemplo(filename: str) -> None:
         "Aparato",
         "Cantidad",
         "Carga",
-        "InicioAM",
-        "FinAM",
-        "InicioPM",
-        "FinPM",
+        "HorasDia",
+        "HorasNoche",
     ])
     ejemplo = [
-        ("Foco LED", 4, 10, 6, 8, 18, 20),
-        ("Laptop", 1, 100, 9, 12, 0, 0),
-        ("Televisor", 1, 80, 0, 0, 19, 22),
+        ("Foco LED", 4, 10, 4, 2),
+        ("Laptop", 1, 100, 2, 0),
+        ("Televisor", 1, 80, 0, 3),
 
     ]
     for fila in ejemplo:
@@ -166,28 +164,24 @@ def leer_cargas(filename: str) -> List[Dict[str, float]]:
             continue
 
         valores = list(row)
-        if len(valores) < 7:
-            valores.extend([0.0] * (7 - len(valores)))
+        if len(valores) < 5:
+            valores.extend([0.0] * (5 - len(valores)))
 
         (
             aparato,
             cantidad,
             carga,
-            inicio_am,
-            fin_am,
-            inicio_pm,
-            fin_pm,
-        ) = valores[:7]
+            horas_dia,
+            horas_noche,
+        ) = valores[:5]
 
         cargas.append(
             {
                 "aparato": str(aparato),
                 "cantidad": float(cantidad),
                 "carga": float(carga),
-                "inicio_am": float(inicio_am),
-                "fin_am": float(fin_am),
-                "inicio_pm": float(inicio_pm),
-                "fin_pm": float(fin_pm),
+                "horas_dia": float(horas_dia),
+                "horas_noche": float(horas_noche),
 
             }
         )
@@ -213,13 +207,12 @@ def seleccionar_cargas_gui(cargas: List[Dict[str, float]]) -> List[Dict[str, flo
         "Aparato",
         "Cantidad",
         "Carga(W)",
-        "InicioAM",
-        "FinAM",
-        "InicioPM",
-        "FinPM",
+        "HorasDia",
+        "HorasNoche",
     ]
     table = QtWidgets.QTableWidget(len(cargas), len(headers))
     table.setHorizontalHeaderLabels(headers)
+    dialog.resize(800, 600)
 
     for row, carga in enumerate(cargas):
         chk_item = QtWidgets.QTableWidgetItem()
@@ -228,10 +221,8 @@ def seleccionar_cargas_gui(cargas: List[Dict[str, float]]) -> List[Dict[str, flo
         table.setItem(row, 1, QtWidgets.QTableWidgetItem(carga["aparato"]))
         table.setItem(row, 2, QtWidgets.QTableWidgetItem(str(carga["cantidad"])))
         table.setItem(row, 3, QtWidgets.QTableWidgetItem(str(carga["carga"])))
-        table.setItem(row, 4, QtWidgets.QTableWidgetItem(str(carga["inicio_am"])))
-        table.setItem(row, 5, QtWidgets.QTableWidgetItem(str(carga["fin_am"])))
-        table.setItem(row, 6, QtWidgets.QTableWidgetItem(str(carga["inicio_pm"])))
-        table.setItem(row, 7, QtWidgets.QTableWidgetItem(str(carga["fin_pm"])))
+        table.setItem(row, 4, QtWidgets.QTableWidgetItem(str(carga["horas_dia"])))
+        table.setItem(row, 5, QtWidgets.QTableWidgetItem(str(carga["horas_noche"])))
 
     layout.addWidget(table)
     boton = QtWidgets.QPushButton("Calcular")
@@ -247,19 +238,15 @@ def seleccionar_cargas_gui(cargas: List[Dict[str, float]]) -> List[Dict[str, flo
             aparato = table.item(row, 1).text()
             cantidad = float(table.item(row, 2).text() or 0)
             carga_w = float(table.item(row, 3).text() or 0)
-            inicio_am = float(table.item(row, 4).text() or 0)
-            fin_am = float(table.item(row, 5).text() or 0)
-            inicio_pm = float(table.item(row, 6).text() or 0)
-            fin_pm = float(table.item(row, 7).text() or 0)
+            horas_dia = float(table.item(row, 4).text() or 0)
+            horas_noche = float(table.item(row, 5).text() or 0)
             resultado.append(
                 {
                     "aparato": aparato,
                     "cantidad": cantidad,
                     "carga": carga_w,
-                    "inicio_am": inicio_am,
-                    "fin_am": fin_am,
-                    "inicio_pm": inicio_pm,
-                    "fin_pm": fin_pm,
+                    "horas_dia": horas_dia,
+                    "horas_noche": horas_noche,
                 }
             )
         dialog.accept()
@@ -304,24 +291,15 @@ def horas_solares_efectivas(curva: Dict[int, float]) -> float:
 def energia_dia_noche(
     cargas: List[Dict[str, float]], curva: Dict[int, float]
 ) -> Tuple[float, float]:
-    """Separa la energia de las cargas en horas con y sin sol."""
+    """Calcula energia consumida de dia y de noche."""
 
     energia_dia = 0.0
     energia_noche = 0.0
 
     for carga in cargas:
         potencia = carga["carga"] * carga["cantidad"]
-        for inicio, fin in [
-            (carga["inicio_am"], carga["fin_am"]),
-            (carga["inicio_pm"], carga["fin_pm"]),
-        ]:
-            if fin <= inicio:
-                continue
-            for hora in range(int(inicio), int(fin)):
-                if curva.get(hora, 0) > 0:
-                    energia_dia += potencia
-                else:
-                    energia_noche += potencia
+        energia_dia += potencia * carga.get("horas_dia", 0)
+        energia_noche += potencia * carga.get("horas_noche", 0)
 
     return energia_dia, energia_noche
 
@@ -341,16 +319,7 @@ def calcular_necesidades(
 def potencia_maxima_demanda(cargas: List[Dict[str, float]]) -> float:
     """Calcula la potencia simultanea maxima de las cargas."""
 
-    demanda_por_hora = {h: 0.0 for h in range(24)}
-    for carga in cargas:
-        potencia = carga["carga"] * carga["cantidad"]
-        for inicio, fin in [
-            (carga["inicio_am"], carga["fin_am"]),
-            (carga["inicio_pm"], carga["fin_pm"]),
-        ]:
-            for hora in range(int(inicio), int(fin)):
-                demanda_por_hora[hora] += potencia
-    return max(demanda_por_hora.values())
+    return sum(carga["carga"] * carga["cantidad"] for carga in cargas)
 
 
 def calcular_kit(


### PR DESCRIPTION
## Summary
- simplify example spreadsheet to request day/night hours
- update load reading and GUI table for new format
- compute energy using hours directly and adjust peak demand
- add PyQt simulation window with buttons for graphs and system info

## Testing
- `python -m py_compile Ahorros.py Precios.py`

------
https://chatgpt.com/codex/tasks/task_b_6865327ac0e4833091c2ea016e72b1a1